### PR TITLE
Class constants are always public

### DIFF
--- a/Helper/MailTemplate.php
+++ b/Helper/MailTemplate.php
@@ -15,7 +15,8 @@ class MailTemplate extends Base
 {
 
     # if you update you should also update variableExpansion
-    public const PATTERN = array ('%task_id', '%task_title', '%task_discription',
+    /* public */
+    const PATTERN = array ('%task_id', '%task_title', '%task_discription',
                                     '%creator_id', '%creator_name', '%creator_email',
                                     '%assignee', '%assignee_name', '%assignee_email',
                                      '%project_id', '%project_email', '%user_name', '%user_email');

--- a/Helper/MailTemplate.php
+++ b/Helper/MailTemplate.php
@@ -16,7 +16,7 @@ class MailTemplate extends Base
 
     # if you update you should also update variableExpansion
     /* public */
-    const PATTERN = array ('%task_id', '%task_title', '%task_discription',
+    const PATTERN = array ('%task_id', '%task_title', '%task_description',
                                     '%creator_id', '%creator_name', '%creator_email',
                                     '%assignee', '%assignee_name', '%assignee_email',
                                      '%project_id', '%project_email', '%user_name', '%user_email');

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ available variables you can use:
 
 * %task_id
 * %task_title
-* %task_discription
+* %task_description
 * %project_id
 * %project_email    (you can change this in: edit project)
 * %user_name


### PR DESCRIPTION
This seems to cause a problem with PHP 7.0.30-0ubuntu0.16.04.1 E.g.,

[Sat Jun 30 17:31:37.077204 2018] [:error] [pid 1234] [client 0.0.0.0:00000] PHP Parse error:  syntax error, unexpected 'const' (T_CONST), expecting variable (T_VARIABLE) in /var/www/kanboard/plugins/ExtendedMail/Helper/MailTemplate.php on line 18

But according to my research they are always going to be public so declaring them public is redundant